### PR TITLE
refactor: allow getDashboardLayoutWidgetInfoList to customize widgets declared more than twice

### DIFF
--- a/src/services/dashboards/default-dashboard/helper.ts
+++ b/src/services/dashboards/default-dashboard/helper.ts
@@ -1,37 +1,39 @@
 import { v4 as uuidv4 } from 'uuid';
 
 import { ERROR_CASE_WIDGET_INFO } from '@/services/dashboards/default-dashboard/config';
-import type { WidgetCustomTitleMap } from '@/services/dashboards/default-dashboard/templates/type';
 import type { DashboardLayoutWidgetInfo, InheritOptions } from '@/services/dashboards/widgets/_configs/config';
 import { getWidgetConfig } from '@/services/dashboards/widgets/_helpers/widget-helper';
 
-export const getDashboardLayoutWidgetInfoList = (widgetList: string[], widgetCustomTitleMap?: WidgetCustomTitleMap): DashboardLayoutWidgetInfo[] => widgetList.map((widgetId) => {
-    try {
-        const widgetConfig = getWidgetConfig(widgetId);
-        const widgetConfigTitle = widgetConfig.title ?? widgetConfig.widget_config_id;
-        const title = widgetCustomTitleMap ? (widgetCustomTitleMap[widgetId] ?? widgetConfigTitle) : widgetConfigTitle;
-        const defaultProperties = widgetConfig.options_schema?.default_properties ?? [];
-        const requiredProperties = widgetConfig.options_schema?.schema.required ?? [];
-        const inheritOptions: InheritOptions = {};
-        defaultProperties.filter((d) => !requiredProperties.includes(d)).forEach((propertyName) => {
-            inheritOptions[propertyName] = {
-                enabled: true,
-                variable_info: { key: propertyName.replace('filters.', '') },
+type WidgetTuple = [widgetId: string]|[widgetId: string, customInfo: Partial<DashboardLayoutWidgetInfo>];
+export const getDashboardLayoutWidgetInfoList = (widgetList: WidgetTuple[]): DashboardLayoutWidgetInfo[] => widgetList.map(
+    ([widgetId, customInfo]) => {
+        try {
+            const widgetConfig = getWidgetConfig(widgetId);
+            const widgetConfigTitle = widgetConfig.title ?? widgetConfig.widget_config_id;
+            const title = customInfo?.title ? (customInfo?.title ?? widgetConfigTitle) : widgetConfigTitle;
+            const defaultProperties = widgetConfig.options_schema?.default_properties ?? [];
+            const requiredProperties = widgetConfig.options_schema?.schema.required ?? [];
+            const inheritOptions: InheritOptions = {};
+            defaultProperties.filter((d) => !requiredProperties.includes(d)).forEach((propertyName) => {
+                inheritOptions[propertyName] = {
+                    enabled: true,
+                    variable_info: { key: propertyName.replace('filters.', '') },
+                };
+            });
+            const widgetInfo: DashboardLayoutWidgetInfo = {
+                widget_key: uuidv4(),
+                widget_name: widgetConfig.widget_config_id,
+                title,
+                widget_options: widgetConfig.options ?? {},
+                size: widgetConfig.sizes[0],
+                version: '1',
+                inherit_options: inheritOptions,
+                default_schema_properties: defaultProperties,
             };
-        });
-        const widgetInfo: DashboardLayoutWidgetInfo = {
-            widget_key: uuidv4(),
-            widget_name: widgetConfig.widget_config_id,
-            title,
-            widget_options: widgetConfig.options ?? {},
-            size: widgetConfig.sizes[0],
-            version: '1',
-            inherit_options: inheritOptions,
-            default_schema_properties: defaultProperties,
-        };
-        return widgetInfo;
-    } catch (e) {
-        console.error(e);
-        return ERROR_CASE_WIDGET_INFO;
-    }
-});
+            return widgetInfo;
+        } catch (e) {
+            console.error(e);
+            return ERROR_CASE_WIDGET_INFO;
+        }
+    },
+);

--- a/src/services/dashboards/default-dashboard/templates/cdn-and-traffic-cost.ts
+++ b/src/services/dashboards/default-dashboard/templates/cdn-and-traffic-cost.ts
@@ -1,12 +1,11 @@
 import type { DashboardConfig } from '@/services/dashboards/config';
 import type { DefaultDashboardPreviewConfig } from '@/services/dashboards/default-dashboard/config';
 import { getDashboardLayoutWidgetInfoList } from '@/services/dashboards/default-dashboard/helper';
-import type { WidgetCustomTitleMap } from '@/services/dashboards/default-dashboard/templates/type';
 
-const widgetList = [
-    'awsDataTransferCostTrend',
-    'awsDataTransferByRegion',
-    'awsCloudFrontCost',
+const widgetList: Parameters<typeof getDashboardLayoutWidgetInfoList>[0] = [
+    ['awsDataTransferCostTrend'],
+    ['awsDataTransferByRegion'],
+    ['awsCloudFrontCost', { title: 'AWS CloudFront Cost by Project' }],
 ];
 
 export const cdnAndTrafficCostDashboardPreview: DefaultDashboardPreviewConfig = {
@@ -17,10 +16,6 @@ export const cdnAndTrafficCostDashboardPreview: DefaultDashboardPreviewConfig = 
         icon: 'ic_dashboard-template_cdn-traffic-cost',
         preview_image: 'cdnAndTrafficCost',
     },
-};
-
-const widgetCustomTitleMap: WidgetCustomTitleMap = {
-    awsCloudFrontCost: 'AWS CloudFront Cost by Project',
 };
 
 export const cdnAndTrafficCostDashboard: DashboardConfig = {
@@ -40,6 +35,6 @@ export const cdnAndTrafficCostDashboard: DashboardConfig = {
     },
     variables: {},
     layouts: [
-        getDashboardLayoutWidgetInfoList(widgetList, widgetCustomTitleMap),
+        getDashboardLayoutWidgetInfoList(widgetList),
     ],
 };

--- a/src/services/dashboards/default-dashboard/templates/monthly-cost-summary.ts
+++ b/src/services/dashboards/default-dashboard/templates/monthly-cost-summary.ts
@@ -1,17 +1,16 @@
 import type { DashboardConfig } from '@/services/dashboards/config';
 import type { DefaultDashboardPreviewConfig } from '@/services/dashboards/default-dashboard/config';
 import { getDashboardLayoutWidgetInfoList } from '@/services/dashboards/default-dashboard/helper';
-import type { WidgetCustomTitleMap } from '@/services/dashboards/default-dashboard/templates/type';
 
-const widgetList = [
-    'monthlyCost',
-    'budgetUsageSummary',
-    'costMap',
-    'costTrend',
-    'costTrendStacked',
-    'costDonut',
-    'budgetStatus',
-    'costByRegion',
+const widgetList: Parameters<typeof getDashboardLayoutWidgetInfoList>[0] = [
+    ['monthlyCost', { title: 'Monthly Cost Overview' }],
+    ['budgetUsageSummary'],
+    ['costMap', { title: 'Cost By Project' }],
+    ['costTrend', { title: 'Cost Trend By Project' }],
+    ['costTrendStacked', { title: 'Cost Trend By Product' }],
+    ['costDonut', { title: 'Cost By Provider' }],
+    ['budgetStatus'],
+    ['costByRegion'],
 ];
 
 export const monthlyCostSummaryDashboardPreview: DefaultDashboardPreviewConfig = {
@@ -22,14 +21,6 @@ export const monthlyCostSummaryDashboardPreview: DefaultDashboardPreviewConfig =
         icon: 'ic_dashboard-template_monthly-cost-summary',
         preview_image: 'monthlyCostSummary',
     },
-};
-
-const widgetCustomTitleMap: WidgetCustomTitleMap = {
-    monthlyCost: 'Monthly Cost Overview',
-    costMap: 'Cost By Project',
-    costTrend: 'Cost Trend By Project',
-    costTrendStacked: 'Cost Trend By Product',
-    costDonut: 'Cost By Provider',
 };
 
 export const monthlyCostSummaryDashboard: DashboardConfig = {
@@ -49,6 +40,6 @@ export const monthlyCostSummaryDashboard: DashboardConfig = {
     },
     variables: {},
     layouts: [
-        getDashboardLayoutWidgetInfoList(widgetList, widgetCustomTitleMap),
+        getDashboardLayoutWidgetInfoList(widgetList),
     ],
 };


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [ ] Feature improvement
- [x] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description

I think current code has two problems below:
1. If other property like inheritOptions must be customized, another argument is needed.
2. If the template uses the same widget more than twice, customized title can not be different because they have the same widget id.

So I changed argument's type.

### Things to Talk About
